### PR TITLE
more fixing

### DIFF
--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDataClassCopyMethodASTTransformation.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDataClassCopyMethodASTTransformation.kt
@@ -5,6 +5,7 @@ import org.codehaus.groovy.ast.AnnotatedNode
 import org.codehaus.groovy.ast.ClassCodeExpressionTransformer
 import org.codehaus.groovy.ast.ClassCodeVisitorSupport
 import org.codehaus.groovy.ast.ClassHelper
+import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.MethodNode
 import org.codehaus.groovy.ast.expr.ArgumentListExpression
 import org.codehaus.groovy.ast.expr.ArrayExpression
@@ -175,6 +176,10 @@ class KotlinDataClassCopyMethodASTTransformation : AbstractASTTransformation() {
       return null
     }
     if (containsSpreadExpression(expr.arguments)) return null
+    // Positional-only constructor calls on non-Kotlin classes don't need
+    // transformation. Transforming them loses compile-time type info
+    // (e.g. casts on null args), causing ambiguity with overloaded constructors.
+    if (precomputedInfo == null && !isKotlinClassNode(expr.type)) return null
     val namedArgMap = precomputedInfo?.namedArgMap ?: MapExpression()
     val positionalExprs = precomputedInfo?.positionalExprs ?: extractPositionalArgs(expr.arguments)
     val namedFirst = precomputedInfo?.namedFirst ?: false
@@ -207,6 +212,9 @@ class KotlinDataClassCopyMethodASTTransformation : AbstractASTTransformation() {
     is TupleExpression -> args.expressions.toList()
     else -> emptyList()
   }
+
+  private fun isKotlinClassNode(classNode: ClassNode): Boolean =
+    classNode.annotations.any { it.classNode.name == "kotlin.Metadata" }
 
   private fun methodNeedsTransformation(node: MethodNode): Boolean {
     var found = false

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDataClassCopyMethodASTTransformation.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDataClassCopyMethodASTTransformation.kt
@@ -167,6 +167,13 @@ class KotlinDataClassCopyMethodASTTransformation : AbstractASTTransformation() {
   ): Expression? {
     if (expr.isSuperCall || expr.isThisCall) return null
     if (expr.isUsingAnonymousInnerClass) return null
+    // Non-static inner classes have an implicit enclosing instance
+    // parameter that constructWithNamedArgs cannot supply.
+    if (expr.type.outerClass != null &&
+      !java.lang.reflect.Modifier.isStatic(expr.type.modifiers)
+    ) {
+      return null
+    }
     if (containsSpreadExpression(expr.arguments)) return null
     val namedArgMap = precomputedInfo?.namedArgMap ?: MapExpression()
     val positionalExprs = precomputedInfo?.positionalExprs ?: extractPositionalArgs(expr.arguments)

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDestructuringExtensions.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDestructuringExtensions.kt
@@ -11,8 +11,18 @@ fun getAt(self: Any, index: Int): Any? {
   val componentNumber = index + 1
   val methodName = "component$componentNumber"
   val method = self.javaClass.methods.find { it.name == methodName && it.parameterCount == 0 }
-    ?: throw IllegalArgumentException(
+  if (method != null) {
+    return method.invoke(self)
+  }
+  // Fall back to standard collection access for types without
+  // component functions (e.g. Map.getAt(key), List.getAt(index)).
+  return when (self) {
+    is Map<*, *> -> self[index]
+
+    is List<*> -> self[index]
+
+    else -> throw IllegalArgumentException(
       "Destructuring declaration initializer of type ${self.javaClass.simpleName} must have a '$methodName()' function",
     )
-  return method.invoke(self)
+  }
 }

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinInterop.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinInterop.kt
@@ -336,9 +336,24 @@ private fun resolveArgs(
     // Positional args first (standard behavior)
     for ((index, value) in positionalArgs.withIndex()) {
       if (index >= params.size) {
+        // Check if the last param is vararg — pack remaining args into it
+        val lastParam = params.last()
+        if (lastParam.isVararg) {
+          val varargValues = positionalArgs.drop(params.size - 1)
+          paramMap[lastParam] = varargValues.toTypedArray()
+          assignedParams += lastParam
+          break
+        }
         throw IllegalArgumentException("Too many arguments")
       }
       val param = params[index]
+      if (param.isVararg && index == params.size - 1 && positionalArgs.size > params.size) {
+        // Pack remaining positional args into the vararg parameter
+        val varargValues = positionalArgs.drop(index)
+        paramMap[param] = varargValues.toTypedArray()
+        assignedParams += param
+        break
+      }
       paramMap[param] = value
       assignedParams += param
     }

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinInterop.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinInterop.kt
@@ -340,7 +340,7 @@ private fun resolveArgs(
         val lastParam = params.last()
         if (lastParam.isVararg) {
           val varargValues = positionalArgs.drop(params.size - 1)
-          paramMap[lastParam] = varargValues.toTypedArray()
+          paramMap[lastParam] = toTypedVarargArray(lastParam, varargValues)
           assignedParams += lastParam
           break
         }
@@ -350,7 +350,7 @@ private fun resolveArgs(
       if (param.isVararg && index == params.size - 1 && positionalArgs.size > params.size) {
         // Pack remaining positional args into the vararg parameter
         val varargValues = positionalArgs.drop(index)
-        paramMap[param] = varargValues.toTypedArray()
+        paramMap[param] = toTypedVarargArray(param, varargValues)
         assignedParams += param
         break
       }
@@ -427,6 +427,13 @@ private fun resolveArgs(
   paramsToRemove.forEach { paramMap.remove(it) }
 
   return paramMap
+}
+
+private fun toTypedVarargArray(param: KParameter, values: List<Any?>): Any {
+  val elementType = param.type.arguments.first().type?.jvmErasure?.java ?: Any::class.java
+  val typedArray = java.lang.reflect.Array.newInstance(elementType, values.size)
+  values.forEachIndexed { i, v -> java.lang.reflect.Array.set(typedArray, i, v) }
+  return typedArray
 }
 
 private fun describeValueType(value: Any): String = when (value) {

--- a/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/ConsumingProjectCompatibilitySpec.groovy
+++ b/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/ConsumingProjectCompatibilitySpec.groovy
@@ -295,4 +295,21 @@ class ConsumingProjectCompatibilitySpec extends Specification {
             classUnderTest.calls[0].arguments == [options: []]
     }
 
+    // Issue 15: Kotlin vararg parameters should accept multiple positional
+    // arguments from Groovy. resolveArgs must pack trailing positional
+    // args into the vararg array instead of throwing "Too many arguments".
+
+    def 'can call Kotlin method with varargs and multiple arguments'() {
+
+        given:
+            def classUnderTest = new ClassWithNoDefaultedArgumentsToMethods()
+
+        when:
+            classUnderTest.functionWithVarargsAny(1, 2, 3, 5, 8)
+
+        then:
+            notThrown(Exception)
+            classUnderTest.calls[0].arguments == [values: [1, 2, 3, 5, 8]]
+    }
+
 }

--- a/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/ConsumingProjectCompatibilitySpec.groovy
+++ b/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/ConsumingProjectCompatibilitySpec.groovy
@@ -313,7 +313,22 @@ class ConsumingProjectCompatibilitySpec extends Specification {
             classUnderTest.calls[0].arguments == [values: [1, 2, 3, 5, 8]]
     }
 
-    // Issue 16: Groovy non-static inner classes have an implicit enclosing
+    // Issue 16: The getAt extension for Kotlin destructuring must not
+    // shadow Groovy's built-in Map.getAt(key) when the object is a Map.
+
+    def 'can use integer key to access map via getAt operator'() {
+
+        given:
+            def map = [200: 42, 500: 3]
+
+        when:
+            def result = map[200]
+
+        then:
+            result == 42
+    }
+
+    // Issue 17: Groovy non-static inner classes have an implicit enclosing
     // instance parameter in their constructor. The AST transform must not
     // rewrite these constructors into constructWithNamedArgs, because the
     // enclosing instance is not passed as a regular argument.

--- a/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/ConsumingProjectCompatibilitySpec.groovy
+++ b/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/ConsumingProjectCompatibilitySpec.groovy
@@ -314,7 +314,24 @@ class ConsumingProjectCompatibilitySpec extends Specification {
             classUnderTest.calls[0].arguments == [values: [1, 2, 3, 5, 8]]
     }
 
-    // Issue 16: The getAt extension for Kotlin destructuring must not
+    // Issue 16: Kotlin typed vararg parameters (e.g. vararg options: String)
+    // must work when called with multiple arguments from Groovy. The packed
+    // array must match the expected element type, not be Object[].
+
+    def 'can call Kotlin method with typed varargs and multiple arguments'() {
+
+        given:
+            def classUnderTest = new ClassWithNoDefaultedArgumentsToMethods()
+
+        when:
+            classUnderTest.functionWithVarargs('a', 'b', 'c')
+
+        then:
+            notThrown(Exception)
+            classUnderTest.calls[0].arguments == [options: ['a', 'b', 'c']]
+    }
+
+    // Issue 17: The getAt extension for Kotlin destructuring must not
     // shadow Groovy's built-in Map.getAt(key) when the object is a Map.
 
     def 'can use integer key to access map via getAt operator'() {

--- a/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/ConsumingProjectCompatibilitySpec.groovy
+++ b/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/ConsumingProjectCompatibilitySpec.groovy
@@ -9,6 +9,7 @@ import uk.org.lidalia.kotlinfromgroovy.testsupport.JavaClassWithoutPrimaryConstr
 import uk.org.lidalia.kotlinfromgroovy.testsupport.GroovySubclass
 import uk.org.lidalia.kotlinfromgroovy.testsupport.OpenClassWithDefaults
 import uk.org.lidalia.kotlinfromgroovy.testsupport.SimpleCallback
+import uk.org.lidalia.kotlinfromgroovy.testsupport.GroovyOuterClassWithInnerClass
 import uk.org.lidalia.kotlinfromgroovy.testsupport.GroovySubclassOfBaseWithPrivateMethod
 
 class ConsumingProjectCompatibilitySpec extends Specification {
@@ -310,6 +311,25 @@ class ConsumingProjectCompatibilitySpec extends Specification {
         then:
             notThrown(Exception)
             classUnderTest.calls[0].arguments == [values: [1, 2, 3, 5, 8]]
+    }
+
+    // Issue 16: Groovy non-static inner classes have an implicit enclosing
+    // instance parameter in their constructor. The AST transform must not
+    // rewrite these constructors into constructWithNamedArgs, because the
+    // enclosing instance is not passed as a regular argument.
+
+    def 'can construct Groovy non-static inner class with named args'() {
+
+        given:
+            def outer = new GroovyOuterClassWithInnerClass()
+
+        when:
+            def inner = outer.createInner('test', 42)
+
+        then:
+            notThrown(Exception)
+            inner.name == 'test'
+            inner.value == 42
     }
 
 }

--- a/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/ConsumingProjectCompatibilitySpec.groovy
+++ b/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/ConsumingProjectCompatibilitySpec.groovy
@@ -5,6 +5,7 @@ import spock.lang.Specification
 import uk.org.lidalia.kotlinfromgroovy.testsupport.ClassThatThrowsInConstructor
 import uk.org.lidalia.kotlinfromgroovy.testsupport.ClassWithDefaultedArgumentsToMethods
 import uk.org.lidalia.kotlinfromgroovy.testsupport.ClassWithNoDefaultedArgumentsToMethods
+import uk.org.lidalia.kotlinfromgroovy.testsupport.JavaClassWithOverloadedConstructors
 import uk.org.lidalia.kotlinfromgroovy.testsupport.JavaClassWithoutPrimaryConstructor
 import uk.org.lidalia.kotlinfromgroovy.testsupport.GroovySubclass
 import uk.org.lidalia.kotlinfromgroovy.testsupport.OpenClassWithDefaults
@@ -345,6 +346,21 @@ class ConsumingProjectCompatibilitySpec extends Specification {
             notThrown(Exception)
             inner.name == 'test'
             inner.value == 42
+    }
+
+    // Issue 18: Java classes with overloaded constructors and null args
+    // must not be transformed when using positional-only args. The AST
+    // transform loses cast type information, causing ambiguity errors.
+
+    def 'can construct Java class with overloaded constructors and null arg'() {
+
+        when:
+            def instance = new JavaClassWithOverloadedConstructors('type', (String) null)
+
+        then:
+            notThrown(Exception)
+            instance.type == 'type'
+            instance.value == null
     }
 
 }

--- a/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/testsupport/GroovyOuterClassWithInnerClass.groovy
+++ b/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/testsupport/GroovyOuterClassWithInnerClass.groovy
@@ -1,0 +1,16 @@
+package uk.org.lidalia.kotlinfromgroovy.testsupport
+
+import groovy.transform.Immutable
+
+class GroovyOuterClassWithInnerClass {
+
+    @Immutable
+    class Inner {
+        String name
+        int value
+    }
+
+    Inner createInner(String name, int value) {
+        new Inner(name: name, value: value)
+    }
+}

--- a/src/test/java/uk/org/lidalia/kotlinfromgroovy/testsupport/JavaClassWithOverloadedConstructors.java
+++ b/src/test/java/uk/org/lidalia/kotlinfromgroovy/testsupport/JavaClassWithOverloadedConstructors.java
@@ -1,0 +1,19 @@
+package uk.org.lidalia.kotlinfromgroovy.testsupport;
+
+import java.util.Locale;
+
+public class JavaClassWithOverloadedConstructors {
+
+    public final String type;
+    public final String value;
+
+    public JavaClassWithOverloadedConstructors(String type, String value) {
+        this.type = type;
+        this.value = value;
+    }
+
+    public JavaClassWithOverloadedConstructors(String type, Locale locale) {
+        this.type = type;
+        this.value = locale != null ? locale.toString() : null;
+    }
+}

--- a/src/test/kotlin/uk/org/lidalia/kotlinfromgroovy/testsupport/ClassWithNoDefaultedArgumentsToMethods.kt
+++ b/src/test/kotlin/uk/org/lidalia/kotlinfromgroovy/testsupport/ClassWithNoDefaultedArgumentsToMethods.kt
@@ -65,4 +65,13 @@ class ClassWithNoDefaultedArgumentsToMethods {
       ),
     )
   }
+
+  fun functionWithVarargsAny(vararg values: Any) {
+    calls += Call(
+      functionName = "functionWithVarargsAny",
+      arguments = linkedMapOf(
+        "values" to values.toList(),
+      ),
+    )
+  }
 }


### PR DESCRIPTION
- **Pack multiple positional args into vararg parameter in resolveArgs**
- **Skip AST transform for non-static inner class constructors**
- **Fall back to Map/List access when getAt finds no component function**
- **Skip AST transform for positional-only constructors on non-Kotlin classes**
- **Fix vararg array type mismatch for typed vararg parameters**
