### PR TITLE
refactoring

### DIFF
--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinAwareMetaClass.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinAwareMetaClass.kt
@@ -126,9 +126,7 @@ internal fun ensureKotlinAwareMetaClass(clazz: Class<*>) {
   val registry = GroovySystem.getMetaClassRegistry()
   val current = registry.getMetaClass(clazz)
   if (current !is KotlinAwareMetaClass) {
-    val wrapped = KotlinAwareMetaClass(current)
-    wrapped.initialize()
-    registry.setMetaClass(clazz, wrapped)
+    registry.setMetaClass(clazz, KotlinAwareMetaClass(current).apply { initialize() })
   }
 }
 
@@ -144,20 +142,10 @@ internal fun installGlobalMetaClassHandler() {
     object : MetaClassRegistry.MetaClassCreationHandle() {
       override fun createNormalMetaClass(theClass: Class<*>, body: MetaClassRegistry): MetaClass {
         val metaClass = original.create(theClass, body)
-        return when {
-          metaClass is KotlinAwareMetaClass -> {
-            metaClass
-          }
-
-          shouldWrapMetaClass(theClass) -> {
-            val wrapped = KotlinAwareMetaClass(metaClass)
-            wrapped.initialize()
-            wrapped
-          }
-
-          else -> {
-            metaClass
-          }
+        return if (metaClass !is KotlinAwareMetaClass && shouldWrapMetaClass(theClass)) {
+          KotlinAwareMetaClass(metaClass).apply { initialize() }
+        } else {
+          metaClass
         }
       }
     },

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinAwareMetaClass.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinAwareMetaClass.kt
@@ -75,32 +75,36 @@ class KotlinAwareMetaClass(delegate: MetaClass) : DelegatingMetaClass(delegate) 
   ): Any? {
     // Groovy puts named args as a LinkedHashMap in the first position,
     // with any positional args after it.
+    val namedArgs: LinkedHashMap<String, Any?>
+    val positionalArgs: Array<Any?>
     if (args.isNotEmpty() && args[0] is LinkedHashMap<*, *>) {
       @Suppress("UNCHECKED_CAST")
-      val namedArgs = args[0] as LinkedHashMap<String, Any?>
-      val positionalArgs = args.drop(1).toTypedArray()
-      try {
-        return resolveKotlinMethodCall(target, name, namedArgs, positionalArgs)
-      } catch (_: MissingMethodException) {
-        // Method not found — try extension functions
-      }
-      try {
-        return resolveKotlinExtensionCall(target, name, namedArgs, positionalArgs)
-      } catch (_: MissingMethodException) {
-        throw original
-      }
+      namedArgs = args[0] as LinkedHashMap<String, Any?>
+      positionalArgs = args.drop(1).toTypedArray()
+    } else {
+      namedArgs = linkedMapOf()
+      positionalArgs = args
     }
-    // Try as positional args with Kotlin default parameter support
-    try {
-      return resolveKotlinMethodCall(target, name, linkedMapOf(), args)
-    } catch (_: MissingMethodException) {
-      // Method not found — try extension functions
-    }
-    try {
-      return resolveKotlinExtensionCall(target, name, linkedMapOf(), args)
-    } catch (_: MissingMethodException) {
-      throw original
-    }
+    return resolveKotlinCall(target, name, namedArgs, positionalArgs, original)
+  }
+}
+
+private fun resolveKotlinCall(
+  target: Any,
+  name: String,
+  namedArgs: LinkedHashMap<String, Any?>,
+  positionalArgs: Array<Any?>,
+  original: MissingMethodException,
+): Any? {
+  try {
+    return resolveKotlinMethodCall(target, name, namedArgs, positionalArgs)
+  } catch (_: MissingMethodException) {
+    // Method not found — try extension functions
+  }
+  try {
+    return resolveKotlinExtensionCall(target, name, namedArgs, positionalArgs)
+  } catch (_: MissingMethodException) {
+    throw original
   }
 }
 

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDataClassCopyMethodASTTransformation.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDataClassCopyMethodASTTransformation.kt
@@ -49,18 +49,10 @@ class KotlinDataClassCopyMethodASTTransformation : AbstractASTTransformation() {
 
         // Detect named args before super.transform, which may convert
         // NamedArgumentListExpression to plain MapExpression
-        val precomputedInfo = when {
-          expr is MethodCallExpression -> {
-            findNamedArgs(expr.arguments)
-          }
-
-          expr is ConstructorCallExpression -> {
-            findNamedArgs(expr.arguments)
-          }
-
-          else -> {
-            null
-          }
+        val precomputedInfo = when (expr) {
+          is MethodCallExpression -> findNamedArgs(expr.arguments)
+          is ConstructorCallExpression -> findNamedArgs(expr.arguments)
+          else -> null
         }
         val withTransformedChildren = super.transform(expr)
         return when (withTransformedChildren) {

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDataClassCopyMethodASTTransformation.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDataClassCopyMethodASTTransformation.kt
@@ -24,6 +24,7 @@ import org.codehaus.groovy.control.CompilePhase
 import org.codehaus.groovy.control.SourceUnit
 import org.codehaus.groovy.transform.AbstractASTTransformation
 import org.codehaus.groovy.transform.GroovyASTTransformation
+import java.lang.reflect.Modifier
 
 private val kotlinInteropClass = ClassHelper.make("uk.org.lidalia.kotlinfromgroovy.KotlinInterop")
 
@@ -158,7 +159,7 @@ class KotlinDataClassCopyMethodASTTransformation : AbstractASTTransformation() {
     // Non-static inner classes have an implicit enclosing instance
     // parameter that constructWithNamedArgs cannot supply.
     if (expr.type.outerClass != null &&
-      !java.lang.reflect.Modifier.isStatic(expr.type.modifiers)
+      !Modifier.isStatic(expr.type.modifiers)
     ) {
       return null
     }

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDataClassCopyMethodASTTransformation.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDataClassCopyMethodASTTransformation.kt
@@ -94,32 +94,27 @@ class KotlinDataClassCopyMethodASTTransformation : AbstractASTTransformation() {
   private fun AnnotatedNode.hasAnnotationNamed(name: String): Boolean =
     annotations.any { it.classNode.name == name }
 
-  private fun findNamedArgs(args: Expression): NamedArgsInfo? {
-    val exprs = when (args) {
-      is TupleExpression -> args.expressions
-      else -> return null
-    }
+  private fun findNamedArgs(args: Expression): NamedArgsInfo? =
+    (args as? TupleExpression)?.expressions?.let { exprs ->
+      val named = exprs.filterIsInstance<NamedArgumentListExpression>().firstOrNull()
+      when {
+        named != null -> {
+          val mapExpr = MapExpression(named.mapEntryExpressions)
+          val positional = exprs.filter { it !is NamedArgumentListExpression }
+          NamedArgsInfo(mapExpr, positional, detectNamedFirst(mapExpr, positional))
+        }
 
-    val named = exprs.filterIsInstance<NamedArgumentListExpression>().firstOrNull()
-    val mapExpr: MapExpression?
-    val positional: List<Expression>
-
-    if (named != null) {
-      mapExpr = MapExpression(named.mapEntryExpressions)
-      positional = exprs.filter { it !is NamedArgumentListExpression }
-    } else {
-      val firstArg = exprs.firstOrNull()
-      if (firstArg is MapExpression && firstArg.mapEntryExpressions.isNotEmpty()) {
-        mapExpr = firstArg
-        positional = exprs.drop(1)
-      } else {
-        return null
+        else -> {
+          val firstArg = exprs.firstOrNull()
+          if (firstArg is MapExpression && firstArg.mapEntryExpressions.isNotEmpty()) {
+            val positional = exprs.drop(1)
+            NamedArgsInfo(firstArg, positional, detectNamedFirst(firstArg, positional))
+          } else {
+            null
+          }
+        }
       }
     }
-
-    val namedFirst = detectNamedFirst(mapExpr, positional)
-    return NamedArgsInfo(mapExpr, positional, namedFirst)
-  }
 
   private fun detectNamedFirst(mapExpr: MapExpression, positional: List<Expression>): Boolean {
     val firstNamed = mapExpr.mapEntryExpressions.firstOrNull()

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDataClassCopyMethodASTTransformation.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDataClassCopyMethodASTTransformation.kt
@@ -122,13 +122,13 @@ class KotlinDataClassCopyMethodASTTransformation : AbstractASTTransformation() {
   }
 
   private fun detectNamedFirst(mapExpr: MapExpression, positional: List<Expression>): Boolean {
-    if (positional.isEmpty() || mapExpr.mapEntryExpressions.isEmpty()) return false
-    val firstNamedLine = mapExpr.mapEntryExpressions.first().lineNumber
-    val firstNamedCol = mapExpr.mapEntryExpressions.first().columnNumber
-    val firstPositionalLine = positional.first().lineNumber
-    val firstPositionalCol = positional.first().columnNumber
-    return firstNamedLine < firstPositionalLine ||
-      (firstNamedLine == firstPositionalLine && firstNamedCol < firstPositionalCol)
+    val firstNamed = mapExpr.mapEntryExpressions.firstOrNull()
+    val firstPos = positional.firstOrNull()
+    return when {
+      firstNamed == null || firstPos == null -> false
+      firstNamed.lineNumber != firstPos.lineNumber -> firstNamed.lineNumber < firstPos.lineNumber
+      else -> firstNamed.columnNumber < firstPos.columnNumber
+    }
   }
 
   private fun transformMethodCall(

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDestructuringExtensions.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinDestructuringExtensions.kt
@@ -11,15 +11,14 @@ fun getAt(self: Any, index: Int): Any? {
   val componentNumber = index + 1
   val methodName = "component$componentNumber"
   val method = self.javaClass.methods.find { it.name == methodName && it.parameterCount == 0 }
-  if (method != null) {
-    return method.invoke(self)
-  }
   // Fall back to standard collection access for types without
   // component functions (e.g. Map.getAt(key), List.getAt(index)).
-  return when (self) {
-    is Map<*, *> -> self[index]
+  return when {
+    method != null -> method.invoke(self)
 
-    is List<*> -> self[index]
+    self is Map<*, *> -> self[index]
+
+    self is List<*> -> self[index]
 
     else -> throw IllegalArgumentException(
       "Destructuring declaration initializer of type ${self.javaClass.simpleName} must have a '$methodName()' function",

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinExtensionFunctionResolver.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinExtensionFunctionResolver.kt
@@ -32,13 +32,12 @@ internal object KotlinExtensionFunctionResolver {
 
     val urls = collectClasspathUrls(classLoader)
 
-    for (url in urls) {
+    urls.forEach { url ->
       try {
         val file = File(URI(url.toString().replace(" ", "%20")))
-        if (file.isDirectory) {
-          scanDirectory(file, file, classLoader, result)
-        } else if (file.name.endsWith(".jar")) {
-          scanJar(file, classLoader, result)
+        when {
+          file.isDirectory -> scanDirectory(file, file, classLoader, result)
+          file.name.endsWith(".jar") -> scanJar(file, classLoader, result)
         }
       } catch (_: Exception) {
         // Skip entries we can't process
@@ -66,14 +65,18 @@ internal object KotlinExtensionFunctionResolver {
     classLoader: ClassLoader,
     result: MutableMap<String, MutableList<ExtensionFunction>>,
   ) {
-    for (file in dir.listFiles() ?: return) {
-      if (file.isDirectory) {
-        scanDirectory(root, file, classLoader, result)
-      } else if (file.name.endsWith("Kt.class") && '$' !in file.name) {
-        val className = file.relativeTo(root).path
-          .removeSuffix(".class")
-          .replace(File.separatorChar, '.')
-        checkClass(className, classLoader, result)
+    (dir.listFiles() ?: return).forEach { file ->
+      when {
+        file.isDirectory -> {
+          scanDirectory(root, file, classLoader, result)
+        }
+
+        file.name.endsWith("Kt.class") && '$' !in file.name -> {
+          val className = file.relativeTo(root).path
+            .removeSuffix(".class")
+            .replace(File.separatorChar, '.')
+          checkClass(className, classLoader, result)
+        }
       }
     }
   }
@@ -84,15 +87,15 @@ internal object KotlinExtensionFunctionResolver {
     result: MutableMap<String, MutableList<ExtensionFunction>>,
   ) {
     JarFile(jarFile).use { jar ->
-      for (entry in jar.entries()) {
-        val name = entry.name
-        if (name.endsWith("Kt.class") && '$' !in name) {
+      jar.entries().asSequence()
+        .map { it.name }
+        .filter { it.endsWith("Kt.class") && '$' !in it }
+        .forEach { name ->
           val className = name
             .removeSuffix(".class")
             .replace('/', '.')
           checkClass(className, classLoader, result)
         }
-      }
     }
   }
 
@@ -107,26 +110,25 @@ internal object KotlinExtensionFunctionResolver {
       val metadata = clazz.getAnnotation(Metadata::class.java) ?: return
       if (metadata.kind != 2) return
 
-      for (method in clazz.declaredMethods) {
-        try {
-          val modifiers = method.modifiers
-          if (!java.lang.reflect.Modifier.isPublic(modifiers)) continue
-          if (!java.lang.reflect.Modifier.isStatic(modifiers)) continue
-          if (method.isSynthetic) continue
-
-          val kFunction = method.kotlinFunction ?: continue
-
-          val receiverParam = kFunction.parameters
-            .find { it.kind == KParameter.Kind.EXTENSION_RECEIVER }
-            ?: continue
-          val receiverType = receiverParam.type.jvmErasure.java
-
-          result.getOrPut(method.name) { mutableListOf() }
-            .add(ExtensionFunction(kFunction, receiverType))
-        } catch (_: Throwable) {
-          // Skip methods we can't inspect (e.g. types kotlin-reflect can't handle)
+      clazz.declaredMethods.asSequence()
+        .filter { java.lang.reflect.Modifier.isPublic(it.modifiers) }
+        .filter { java.lang.reflect.Modifier.isStatic(it.modifiers) }
+        .filter { !it.isSynthetic }
+        .mapNotNull { method ->
+          try {
+            val kFunction = method.kotlinFunction ?: return@mapNotNull null
+            val receiverParam = kFunction.parameters
+              .find { it.kind == KParameter.Kind.EXTENSION_RECEIVER }
+              ?: return@mapNotNull null
+            val receiverType = receiverParam.type.jvmErasure.java
+            method.name to ExtensionFunction(kFunction, receiverType)
+          } catch (_: Throwable) {
+            null
+          }
         }
-      }
+        .forEach { (name, ext) ->
+          result.getOrPut(name) { mutableListOf() }.add(ext)
+        }
     } catch (_: Exception) {
       // Skip classes we can't load or inspect
     }

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinExtensionFunctionResolver.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinExtensionFunctionResolver.kt
@@ -49,19 +49,13 @@ internal object KotlinExtensionFunctionResolver {
   }
 
   private fun collectClasspathUrls(classLoader: ClassLoader): List<URL> {
-    val urls = mutableListOf<URL>()
-    var current: ClassLoader? = classLoader
-    while (current != null) {
-      if (current is URLClassLoader) {
-        urls.addAll(current.urLs)
-      }
-      current = current.parent
-    }
+    val urls = generateSequence<ClassLoader>(classLoader) { it.parent }
+      .filterIsInstance<URLClassLoader>()
+      .flatMap { it.urLs.asSequence() }
+      .toMutableList()
     if (urls.isEmpty()) {
       val cp = System.getProperty("java.class.path") ?: return urls
-      for (entry in cp.split(File.pathSeparator)) {
-        urls.add(File(entry).toURI().toURL())
-      }
+      cp.split(File.pathSeparator).mapTo(urls) { File(it).toURI().toURL() }
     }
     return urls
   }

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinExtensionFunctionResolver.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinExtensionFunctionResolver.kt
@@ -1,6 +1,7 @@
 package uk.org.lidalia.kotlinfromgroovy
 
 import java.io.File
+import java.lang.reflect.Modifier
 import java.net.URI
 import java.net.URL
 import java.net.URLClassLoader
@@ -111,8 +112,8 @@ internal object KotlinExtensionFunctionResolver {
       if (metadata.kind != 2) return
 
       clazz.declaredMethods.asSequence()
-        .filter { java.lang.reflect.Modifier.isPublic(it.modifiers) }
-        .filter { java.lang.reflect.Modifier.isStatic(it.modifiers) }
+        .filter { Modifier.isPublic(it.modifiers) }
+        .filter { Modifier.isStatic(it.modifiers) }
         .filter { !it.isSynthetic }
         .mapNotNull { method ->
           try {

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinInterop.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinInterop.kt
@@ -100,8 +100,7 @@ fun constructWithNamedArgs(
   // Try Groovy's default constructor resolution first
   if (namedArgs.isEmpty()) {
     try {
-      @Suppress("UNCHECKED_CAST")
-      return InvokerHelper.invokeConstructorOf(clazz, positionalArgs) as Any
+      return groovyConstruct(clazz, positionalArgs)
     } catch (_: Exception) {
       // Fall back to Kotlin reflection
     }
@@ -111,9 +110,7 @@ fun constructWithNamedArgs(
   val constructor = kClass.primaryConstructor
   if (constructor == null) {
     // Java class or class without primary constructor — use Groovy dispatch
-    val groovyArgs = buildGroovyArgs(namedArgs, positionalArgs)
-    @Suppress("UNCHECKED_CAST")
-    return InvokerHelper.invokeConstructorOf(clazz, groovyArgs) as Any
+    return groovyConstruct(clazz, buildGroovyArgs(namedArgs, positionalArgs))
   }
 
   try {
@@ -133,10 +130,8 @@ fun constructWithNamedArgs(
     // value misidentified as named args by the AST transform.
     // Try Groovy dispatch with the map as a positional argument;
     // if that also fails, re-throw the original error.
-    val groovyArgs = buildGroovyArgs(namedArgs, positionalArgs)
     try {
-      @Suppress("UNCHECKED_CAST")
-      return InvokerHelper.invokeConstructorOf(clazz, groovyArgs) as Any
+      return groovyConstruct(clazz, buildGroovyArgs(namedArgs, positionalArgs))
     } catch (_: Exception) {
       throw e
     }
@@ -267,6 +262,10 @@ private fun callByUnwrapping(callable: KCallable<*>, paramMap: Map<KParameter, A
 } catch (e: InvocationTargetException) {
   throw e.cause ?: e
 }
+
+@Suppress("UNCHECKED_CAST")
+private fun groovyConstruct(clazz: Class<*>, args: Array<Any?>): Any =
+  InvokerHelper.invokeConstructorOf(clazz, args) as Any
 
 private fun buildGroovyArgs(
   namedArgs: LinkedHashMap<String, Any?>,

--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinInterop.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinInterop.kt
@@ -301,95 +301,146 @@ private fun resolveArgs(
   val paramMap = mutableMapOf<KParameter, Any?>()
   val assignedParams = mutableSetOf<KParameter>()
 
-  // Validate named arg names
-  for (name in namedArgs.keys) {
-    val param = params.find { it.name == name }
-      ?: throw UnknownNamedParameterException(name)
-  }
+  validateNamedArgNames(params, namedArgs)
 
   if (namedFirst && positionalArgs.isNotEmpty() && namedArgs.isNotEmpty()) {
-    // Named args were written before positional args in source.
-    // Assign named args by name first, then positional args fill slots
-    // after the highest-indexed named parameter.
-    for ((name, value) in namedArgs) {
-      val param = params.find { it.name == name }!!
-      paramMap[param] = value
-      assignedParams += param
-    }
-
-    val highestNamedIndex = namedArgs.keys
-      .map { name -> params.indexOfFirst { it.name == name } }
-      .max()
-
-    val slotsAfterNamed = params
-      .filterIndexed { index, param -> index > highestNamedIndex && param !in assignedParams }
-
-    if (positionalArgs.size > slotsAfterNamed.size) {
-      throw IllegalArgumentException("Mixing named and positioned arguments is not allowed")
-    }
-
-    for ((param, value) in slotsAfterNamed.zip(positionalArgs.toList())) {
-      paramMap[param] = value
-      assignedParams += param
-    }
+    assignNamedFirst(params, namedArgs, positionalArgs, paramMap, assignedParams)
   } else {
-    // Positional args first (standard behavior)
-    for ((index, value) in positionalArgs.withIndex()) {
-      if (index >= params.size) {
-        // Check if the last param is vararg — pack remaining args into it
-        val lastParam = params.last()
-        if (lastParam.isVararg) {
-          val varargValues = positionalArgs.drop(params.size - 1)
-          paramMap[lastParam] = toTypedVarargArray(lastParam, varargValues)
-          assignedParams += lastParam
-          break
-        }
-        throw IllegalArgumentException("Too many arguments")
-      }
-      val param = params[index]
-      if (param.isVararg && index == params.size - 1 && positionalArgs.size > params.size) {
-        // Pack remaining positional args into the vararg parameter
-        val varargValues = positionalArgs.drop(index)
-        paramMap[param] = toTypedVarargArray(param, varargValues)
-        assignedParams += param
-        break
-      }
-      paramMap[param] = value
-      assignedParams += param
-    }
-
-    for ((name, value) in namedArgs) {
-      val param = params.find { it.name == name }!!
-      if (param in assignedParams) {
-        throw IllegalArgumentException("An argument is already passed for this parameter")
-      }
-      paramMap[param] = value
-      assignedParams += param
-    }
+    assignPositionalFirst(params, namedArgs, positionalArgs, paramMap, assignedParams)
   }
 
-  // Check for missing required params.
+  fillMissingRequiredParams(params, assignedParams, paramMap)
+  validateAndCoerceArgs(paramMap, validateNullability)
+
+  return paramMap
+}
+
+private fun validateNamedArgNames(
+  params: List<KParameter>,
+  namedArgs: LinkedHashMap<String, Any?>,
+) {
+  namedArgs.keys.forEach { name ->
+    params.find { it.name == name }
+      ?: throw UnknownNamedParameterException(name)
+  }
+}
+
+private fun assignNamedFirst(
+  params: List<KParameter>,
+  namedArgs: LinkedHashMap<String, Any?>,
+  positionalArgs: Array<Any?>,
+  paramMap: MutableMap<KParameter, Any?>,
+  assignedParams: MutableSet<KParameter>,
+) {
+  // Named args were written before positional args in source.
+  // Assign named args by name first, then positional args fill slots
+  // after the highest-indexed named parameter.
+  namedArgs.forEach { (name, value) ->
+    val param = params.find { it.name == name }!!
+    paramMap[param] = value
+    assignedParams += param
+  }
+
+  val highestNamedIndex = namedArgs.keys
+    .map { name -> params.indexOfFirst { it.name == name } }
+    .max()
+
+  val slotsAfterNamed = params
+    .filterIndexed { index, param -> index > highestNamedIndex && param !in assignedParams }
+
+  if (positionalArgs.size > slotsAfterNamed.size) {
+    throw IllegalArgumentException("Mixing named and positioned arguments is not allowed")
+  }
+
+  slotsAfterNamed.zip(positionalArgs.toList()).forEach { (param, value) ->
+    paramMap[param] = value
+    assignedParams += param
+  }
+}
+
+private fun assignPositionalFirst(
+  params: List<KParameter>,
+  namedArgs: LinkedHashMap<String, Any?>,
+  positionalArgs: Array<Any?>,
+  paramMap: MutableMap<KParameter, Any?>,
+  assignedParams: MutableSet<KParameter>,
+) {
+  assignPositionalArgs(params, positionalArgs, paramMap, assignedParams)
+
+  namedArgs.forEach { (name, value) ->
+    val param = params.find { it.name == name }!!
+    if (param in assignedParams) {
+      throw IllegalArgumentException("An argument is already passed for this parameter")
+    }
+    paramMap[param] = value
+    assignedParams += param
+  }
+}
+
+private fun assignPositionalArgs(
+  params: List<KParameter>,
+  positionalArgs: Array<Any?>,
+  paramMap: MutableMap<KParameter, Any?>,
+  assignedParams: MutableSet<KParameter>,
+) {
+  val lastParam = params.lastOrNull()
+  val varargIndex = if (lastParam?.isVararg == true) params.size - 1 else -1
+
+  when {
+    varargIndex >= 0 && positionalArgs.size > varargIndex -> {
+      // Assign non-vararg positional args, then pack remainder into vararg
+      positionalArgs.take(varargIndex).forEachIndexed { index, value ->
+        paramMap[params[index]] = value
+        assignedParams += params[index]
+      }
+      paramMap[lastParam!!] = toTypedVarargArray(lastParam, positionalArgs.drop(varargIndex))
+      assignedParams += lastParam
+    }
+
+    positionalArgs.size <= params.size -> {
+      positionalArgs.forEachIndexed { index, value ->
+        paramMap[params[index]] = value
+        assignedParams += params[index]
+      }
+    }
+
+    else -> {
+      throw IllegalArgumentException("Too many arguments")
+    }
+  }
+}
+
+private fun fillMissingRequiredParams(
+  params: List<KParameter>,
+  assignedParams: Set<KParameter>,
+  paramMap: MutableMap<KParameter, Any?>,
+) {
   // Nullable params without defaults are filled with null to match
   // Groovy's behavior of coercing omitted trailing args to null.
-  for (param in params) {
-    if (param !in assignedParams && !param.isOptional) {
-      if (param.isVararg) {
-        // Vararg params are implicitly optional — default to empty array
-      } else if (param.type.isMarkedNullable) {
+  // Vararg params are implicitly optional — default to empty array.
+  params
+    .filter { it !in assignedParams && !it.isOptional && !it.isVararg }
+    .forEach { param ->
+      if (param.type.isMarkedNullable) {
         paramMap[param] = null
       } else {
         throw IllegalArgumentException("No value passed for parameter '${param.name}'")
       }
     }
-  }
+}
 
+private fun validateAndCoerceArgs(
+  paramMap: MutableMap<KParameter, Any?>,
+  validateNullability: Boolean,
+) {
   // Validate argument types and nullability.
   // When null is passed for a non-null param that has a default,
   // remove it from the map so callBy uses the Kotlin default value.
   // This matches Groovy's convention where null means "unspecified."
   val paramsToRemove = mutableListOf<KParameter>()
-  for ((param, value) in paramMap) {
-    if (value == null) {
+  paramMap.forEach { (param, value) ->
+    val effective = value?.let { unwrapGroovyWrapper(it) }
+    if (effective == null) {
       if (!param.type.isMarkedNullable && param.isOptional) {
         paramsToRemove += param
       } else if (validateNullability && !param.type.isMarkedNullable) {
@@ -397,36 +448,25 @@ private fun resolveArgs(
           "Null passed for non-null parameter '${param.name}'",
         )
       }
-    } else {
-      val unwrapped = unwrapGroovyWrapper(value)
-      if (unwrapped == null) {
-        if (!param.type.isMarkedNullable && param.isOptional) {
-          paramsToRemove += param
-        } else if (validateNullability && !param.type.isMarkedNullable) {
-          throw NullPointerException(
-            "Null passed for non-null parameter '${param.name}'",
-          )
-        }
+      if (value != null) {
         paramMap[param] = null
-      } else {
-        val coerced = coerceGroovyType(unwrapped, param)
-        if (!param.type.jvmErasure.isInstance(coerced)) {
-          val typeDesc = describeValueType(coerced)
-          val expectedName = param.type.jvmErasure.simpleName
-          throw IllegalArgumentException(
-            "The $typeDesc does not conform to the expected type $expectedName",
-          )
-        }
-        if (coerced !== value) {
-          paramMap[param] = coerced
-        }
+      }
+    } else {
+      val coerced = coerceGroovyType(effective, param)
+      if (!param.type.jvmErasure.isInstance(coerced)) {
+        val typeDesc = describeValueType(coerced)
+        val expectedName = param.type.jvmErasure.simpleName
+        throw IllegalArgumentException(
+          "The $typeDesc does not conform to the expected type $expectedName",
+        )
+      }
+      if (coerced !== value) {
+        paramMap[param] = coerced
       }
     }
   }
 
   paramsToRemove.forEach { paramMap.remove(it) }
-
-  return paramMap
 }
 
 private fun toTypedVarargArray(param: KParameter, values: List<Any?>): Any {


### PR DESCRIPTION
- **Replace while loop with generateSequence in collectClasspathUrls**
- **Replace for loops with functional APIs in KotlinExtensionFunctionResolver**
- **Simplify when expression to use when(expr) with smart casts**
- **Extract resolveArgs into focused functions and use functional APIs**
- **Remove early return in getAt by combining into single when expression**
- **Extract resolveKotlinCall to deduplicate try-method/try-extension pattern**
- **Simplify KotlinAwareMetaClass wrapping with apply and if/else**
- **Simplify detectNamedFirst with single exit point and firstOrNull**
- **Refactor findNamedArgs to single exit point using let and when**
- **Use explicit Modifier import instead of fully qualified references**
- **Extract groovyConstruct helper to deduplicate invokeConstructorOf calls**
