### PR TITLE
Add Groovy extension for kotlin.Pair creation

### DIFF
--- a/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinPairExtensions.kt
+++ b/src/main/kotlin/uk/org/lidalia/kotlinfromgroovy/KotlinPairExtensions.kt
@@ -1,0 +1,5 @@
+@file:JvmName("KotlinPairExtensions")
+
+package uk.org.lidalia.kotlinfromgroovy
+
+fun <A, B> to(self: A, that: B): Pair<A, B> = self to that

--- a/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,3 +1,3 @@
 moduleName=kotlin-from-groovy
 moduleVersion=1.0
-extensionClasses=uk.org.lidalia.kotlinfromgroovy.KotlinDestructuringExtensions
+extensionClasses=uk.org.lidalia.kotlinfromgroovy.KotlinDestructuringExtensions,uk.org.lidalia.kotlinfromgroovy.KotlinPairExtensions

--- a/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/PairCreationSpec.groovy
+++ b/src/test/groovy/uk/org/lidalia/kotlinfromgroovy/PairCreationSpec.groovy
@@ -1,0 +1,26 @@
+package uk.org.lidalia.kotlinfromgroovy
+
+import kotlin.Pair
+import spock.lang.Specification
+
+class PairCreationSpec extends Specification {
+
+    def 'can create a Pair using to'() {
+
+        when:
+            def result = 'key'.to('value')
+
+        then:
+            result == new Pair('key', 'value')
+    }
+
+    def 'can destructure a Pair created with to'() {
+
+        when:
+            def (key, value) = 'key'.to('value')
+
+        then:
+            key == 'key'
+            value == 'value'
+    }
+}


### PR DESCRIPTION
Mirrors Kotlin's `to` infix function so Groovy code
can write `'key'.to('value')` instead of
`new Pair('key', 'value')`.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
